### PR TITLE
Consider word orders in other languages

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -20,12 +20,12 @@
 namespace Timer {
 
     public class MainWindow : Gtk.Window {
-        private const string FINISHED_SUFFIX = " finished";
     	private Settings settings;
         public int uid { get; construct set; }
         public string? timer_name { get; construct set; }
         public string timer { get; construct set; }
         TimerManager timer_manager;
+        private bool is_finished;
 
 		public MainWindow (Gtk.Application application, int window_id, string? name, string? t_set) {
 			Object (application: application,
@@ -88,8 +88,9 @@ namespace Timer {
 
             timer_manager.new_timer_set.connect ((t) => {
                 focus (Gtk.DirectionType.UP);
-                if (title.text.has_suffix (FINISHED_SUFFIX)) {
-                    title.text = title.text.replace (FINISHED_SUFFIX, "");
+                if (is_finished) {
+                    title.text = title.last_title;
+                    is_finished = false;
                 }
                 t.start ();
                 if (uid == 0)
@@ -104,8 +105,9 @@ namespace Timer {
             });
             timer_manager.timer_finished.connect ((t) => {
                 time_entry.set_progress_fraction (t.time_elapsed_percentage);
-                if (!title.text.has_suffix (FINISHED_SUFFIX)) {
-                    title.text = title.text + FINISHED_SUFFIX;
+                if (!is_finished) {
+                    title.text = _("%s finished").printf (title.text);
+                    is_finished = true;
                 }
                 if (!timer_manager.stop_notify)
                     time_entry.text = title.text;

--- a/src/TitleLabel.vala
+++ b/src/TitleLabel.vala
@@ -19,7 +19,7 @@
 
 namespace Timer {
 public class TitleLabel : Gtk.Entry {
-	string last_title;
+	public string last_title { get; private set; }
 
 	public signal void unfocus ();
 	public TitleLabel (string? timer_name) {


### PR DESCRIPTION
I found there is a problem in word orders while I was trying to make the app itself and metadata files (like `.appdata.xml` or `.desktop` files) translatable in my forked repository.

![Screenshot from 2019-07-20 11-58-15](https://user-images.githubusercontent.com/26003928/61573213-ae4c9d00-aae5-11e9-8277-126d7f0907cc.png)

In the current code, the label in the titlebar changes to `<timername> finished` when the countdown finished. And then if users restart the timer, the label in the headerbar is back to `<timername>`. This operation is done by adding/removing the constant string " finished" at the end of timername. This works well in the case of English.

However, in some language this does not work, because in some language word orders are different from English one, thus the changed label should be `finished <timername>` instead of `<timername> finished`.

This PR allows translators to change the word order of "<timername> finished" and fixes this problem.
